### PR TITLE
Allow uglifyjs options

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,13 +113,14 @@ var exports = {
   /**
    * Uglify the stream.
    */
-  uglifyJs: function uglifyJs() {
+  uglifyJs: function uglifyJs(options) {
+    options = options || {};
+    options.fromString = true;
+
     return through2.obj(function(file, encoding, cb) {
       try {
         var cleaned = filterInlineScript(String(file.contents), function(text) {
-          return uglify.minify(text, {
-            fromString: true
-          }).code;
+          return uglify.minify(text, options).code;
         });
         file.contents = new Buffer(cleaned);
         cb(null, file);


### PR DESCRIPTION
Some libraries break with mangling enabled, we should accommodate them.

Notably, [rickshaw](https://github.com/shutterstock/rickshaw) is broken due to the mangling that uglify performs by default. https://github.com/shutterstock/rickshaw/issues/52 specifically addresses this.
