### PR TITLE
Fix trimming of spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,9 +139,11 @@ var exports = {
         var cleaned = filterInlineStyles(String(file.contents), function(text) {
           // remove newlines
           return text.replace(/[\r\n]/g, '')
-          // remove 2 or more spaces
-          // (single spaces can be syntactically significant)
-          .replace(/ {2,}/g, '');
+          // reduce 2 or more spaces to one
+          // and remove all leading and trailing spaces
+          .replace(/ {2,}/g, ' ')
+          .replace(/(^|[;,\:\{\}]) /g, '$1')
+          .replace(/ ($|[;,\:\{\}])/g, '$1');
         });
         file.contents = new Buffer(cleaned);
         cb(null, file);


### PR DESCRIPTION
Removing all occurrences of 2 spaces is dangerous. For example look at the following definition used in https://github.com/polymerelements/paper-styles:

``` css
--shadow-elevation-16dp: {
  box-shadow:
    0 16px 24px 2px rgba(0, 0, 0, 0.14),
    0  6px 30px 5px rgba(0, 0, 0, 0.12),
    0  8px 10px -5px rgba(0, 0, 0, 0.4);
};
```

For indentation reasons the authors have used two spaces between `0` and `6px`/`8px`. Replacing two spaces or more with nothing would result in `06px` / `08px`.

This pull requests solves this by reducing two or more spaces to one (two or more will always have the same meaning as one) and by removing leading and trailing spaces afterwards.
